### PR TITLE
[Feature] 뒤로가기 스크립트 작성 & 메인씬 - 자연재해 씬 연결 & UI 통일성 

### DIFF
--- a/Assets/01.Scenes/HyeokBin/TyphoonScene - PracticeandReal.unity
+++ b/Assets/01.Scenes/HyeokBin/TyphoonScene - PracticeandReal.unity
@@ -554,6 +554,81 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 11587353}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &16975703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 16975704}
+  - component: {fileID: 16975706}
+  - component: {fileID: 16975705}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &16975704
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16975703}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1855343885}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1600, y: 749}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &16975705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16975703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ebf9e47b2a26f544aa2fa9cb3a11190b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &16975706
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16975703}
+  m_CullTransparentMesh: 1
 --- !u!1 &19011561
 GameObject:
   m_ObjectHideFlags: 0
@@ -7354,6 +7429,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 415645764}
+  - component: {fileID: 415645765}
   m_Layer: 0
   m_Name: RealTyphoonManager
   m_TagString: Untagged
@@ -7379,6 +7455,26 @@ Transform:
   - {fileID: 563653735}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &415645765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 415645763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad4a7b82845dc4c41a183e4b6d896e34, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  theGameStateManager: {fileID: 1472752615}
+  stageStep: 0
+  feedbackCanvas: {fileID: 1855343884}
+  feedbackText: {fileID: 1746539228}
+  textManager: {fileID: 95549883}
+  player: {fileID: 876978119}
+  window: {fileID: 1964379533}
+  getCompletedActionList: 000000
 --- !u!1 &417362873
 GameObject:
   m_ObjectHideFlags: 0
@@ -9539,7 +9635,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tvScreen: {fileID: 1991005076}
   pracitceGameManager: {fileID: 1393488167}
-  realGameManager: {fileID: 836207710}
+  realGameManager: {fileID: 415645765}
   practicetextManager: {fileID: 1344606386}
   realtextManager: {fileID: 95549883}
   timerManager: {fileID: 563653736}
@@ -13309,7 +13405,6 @@ GameObject:
   m_Component:
   - component: {fileID: 836207709}
   - component: {fileID: 836207707}
-  - component: {fileID: 836207710}
   m_Layer: 0
   m_Name: RealTyphoonManager
   m_TagString: Untagged
@@ -13345,26 +13440,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 415645764}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &836207710
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 836207706}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad4a7b82845dc4c41a183e4b6d896e34, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  theGameStateManager: {fileID: 1472752615}
-  stageStep: 0
-  feedbackCanvas: {fileID: 1855343884}
-  feedbackText: {fileID: 1746539228}
-  textManager: {fileID: 95549883}
-  player: {fileID: 876978119}
-  window: {fileID: 1964379533}
-  getCompletedActionList: 000000
 --- !u!1001 &844262385
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17468,78 +17543,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1022118530}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1024222219
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1024222220}
-  - component: {fileID: 1024222222}
-  - component: {fileID: 1024222221}
-  m_Layer: 5
-  m_Name: RawImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1024222220
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024222219}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1855343885}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1000, y: 700}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1024222221
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024222219}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.4009434, g: 0.59134734, b: 1, a: 0.78431374}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Texture: {fileID: 0}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
---- !u!222 &1024222222
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024222219}
-  m_CullTransparentMesh: 1
 --- !u!4 &1026831087 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400006, guid: 23134583f12e77b4cba178bbfcb9bd6f,
@@ -20652,7 +20655,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManager: {fileID: 1393488167}
-  realGameManager: {fileID: 836207710}
+  realGameManager: {fileID: 415645765}
   textManager: {fileID: 1344606386}
   interactIndex: 3
 --- !u!1001 &1204175117
@@ -23468,7 +23471,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   stageStepCount: 4
   currentStepCount: 0
-  clearUIPanel: {fileID: 0}
+  clearUIPanel: {fileID: 1855343881}
+  clearTextcomponent: {fileID: 1746539228}
   textManager: {fileID: 1344606386}
 --- !u!114 &1393488168
 MonoBehaviour:
@@ -25055,7 +25059,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentState: 0
-  theStageFlowManager: {fileID: 836207710}
+  theStageFlowManager: {fileID: 415645765}
 --- !u!1001 &1480951420
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28971,7 +28975,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1000, y: 500}
+  m_SizeDelta: {x: 1200, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1746539228
 MonoBehaviour:
@@ -30728,8 +30732,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1024222220}
   - {fileID: 1746539227}
+  - {fileID: 16975704}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -31381,7 +31385,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManager: {fileID: 1393488167}
-  realGameManager: {fileID: 836207710}
+  realGameManager: {fileID: 415645765}
   textManager: {fileID: 1344606386}
   offSwitch: {fileID: 47177333}
   onSwitch: {fileID: 290833450}
@@ -33548,7 +33552,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManager: {fileID: 1393488167}
-  realGameManager: {fileID: 836207710}
+  realGameManager: {fileID: 415645765}
   textManager: {fileID: 1344606386}
   allWindowCount: 8
   currentWindowCount: 0

--- a/Assets/01.Scenes/HyeokBin/TyphoonScene - PracticeandReal.unity
+++ b/Assets/01.Scenes/HyeokBin/TyphoonScene - PracticeandReal.unity
@@ -13906,6 +13906,7 @@ GameObject:
   - component: {fileID: 876978117}
   - component: {fileID: 876978116}
   - component: {fileID: 876978119}
+  - component: {fileID: 876978120}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -13991,6 +13992,19 @@ MonoBehaviour:
   tape: {fileID: 1924833500}
   startPosition: {x: 0, y: 0, z: 0}
   isGrabTape: 0
+--- !u!114 &876978120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 876978115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d3ecb3d8652514b90b5c382e66bdc0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hand: 0
 --- !u!1 &877573639
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/02.Scripts/Interaction/BackToMainSceneScript.cs
+++ b/Assets/02.Scripts/Interaction/BackToMainSceneScript.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.SceneManagement; // 씬 관리 필수
+using HTC.UnityPlugin.Vive;
+
+public class BackToMainSceneScript : MonoBehaviour
+{
+    public HandRole hand = HandRole.RightHand;
+
+    void Update()
+    {
+        // Grip 버튼 눌렀을 때
+        if (ViveInput.GetPressDown(hand, ControllerButton.Grip))
+        {
+            // 현재 씬 이름이 Mainscene이 아니라면
+            if (SceneManager.GetActiveScene().name != "Mainscene")
+            {
+                SceneManager.LoadScene("Mainscene");
+            }
+        }
+    }
+}

--- a/Assets/02.Scripts/Interaction/BackToMainSceneScript.cs.meta
+++ b/Assets/02.Scripts/Interaction/BackToMainSceneScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5d3ecb3d8652514b90b5c382e66bdc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02.Scripts/MainStateManager.cs
+++ b/Assets/02.Scripts/MainStateManager.cs
@@ -108,7 +108,7 @@ public class MainStateManager : MonoBehaviour
         // 실전 모드 선택시, 이 버튼을 누르는 시점에서 바로 씬 전환되어야 함
         if(ModeManagerScript.Instance.isRealMode)
         {
-            int randSceneIdx = Random.Range(3, 6);
+            int randSceneIdx = Random.Range(4, 7);
             objectList[7].GetComponent<SceneLoadButtonScript>().LoadScene(randSceneIdx);
         }
         isNatural = false;
@@ -120,7 +120,7 @@ public class MainStateManager : MonoBehaviour
         // 실전 모드 선택시, 이 버튼을 누르는 시점에서 바로 씬 전환되어야 함
         if(ModeManagerScript.Instance.isRealMode)
         {
-            int randSceneIdx = /*Random.Range(0, 3);*/ 0;
+            int randSceneIdx = Random.Range(1, 4);
             objectList[6].GetComponent<SceneLoadButtonScript>().LoadScene(randSceneIdx);
         }
         isNatural = true;

--- a/Assets/02.Scripts/TyphoonScript/TyphoonPracticeModeManagerScript.cs
+++ b/Assets/02.Scripts/TyphoonScript/TyphoonPracticeModeManagerScript.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using TMPro;
 
 public class TyphoonPracticeModeManagerScript : MonoBehaviour, IManagerObjCount
 {
@@ -9,6 +10,8 @@ public class TyphoonPracticeModeManagerScript : MonoBehaviour, IManagerObjCount
     public int currentStepCount = 0; // 현재 단계
     [SerializeField]
     private GameObject clearUIPanel; // ui 오브젝트 연결
+    [SerializeField]
+    private TextMeshProUGUI clearTextcomponent;
     [SerializeField]
     private TextUIManagerScript textManager;
     private Coroutine endingCoroutine;
@@ -49,7 +52,8 @@ public class TyphoonPracticeModeManagerScript : MonoBehaviour, IManagerObjCount
     IEnumerator EndingCoroutine()
     {
         yield return StartCoroutine(GetComponent<TyphoonEndingFadeInOutScript>().FadeCoroutine());
-        textManager.ActivateUIWithText();
+        clearUIPanel.SetActive(true);
+        clearTextcomponent.text = "연습 모드가 종료되었습니다.\n\n태풍이 완전히 지나갈 때까지는 연락 매체를 통해 외부와 소통하며\n\n실내에서 대기하는 것이 좋습니다.\n\n그립 버튼으로 메인 씬으로 돌아가기";
         endingCoroutine = null;
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,15 +5,18 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: Assets/11.Packages/HousePackage2/Scenes/WinterHousePC.unity
-    guid: 99c9720ab356a0642a771bea13969a05
-  - enabled: 0
-    path: Assets/HTC.UnityPlugin/ViveInputUtility/Examples/0.Tutorial/Tutorial.unity
-    guid: 62223332a39faa941b994704be3fb708
   - enabled: 1
-    path: Assets/01.Scenes/HyeokBin/Typhoon - XRpracticeScene.unity
-    guid: 4ed57bba87a77474ea1cdf5b7900d16a
+    path: Assets/01.Scenes/JungHa/MainScene.unity
+    guid: 606ad5d2ef5fe434cae0a0842a2478c3
+  - enabled: 1
+    path: Assets/01.Scenes/RackHyun/FireSimulation_LowFloor.unity
+    guid: 7793cf065ddec94418826b4edbfd6dfa
+  - enabled: 1
+    path: Assets/01.Scenes/HyeokBin/TyphoonScene - PracticeandReal.unity
+    guid: 1ded025b99ad1f944b6d1665ecc6cf87
+  - enabled: 1
+    path: Assets/01.Scenes/JungHa/Earthquake.unity
+    guid: e99d0051b72d74ab898cd430aecffba8
   m_configObjects:
     Unity.XR.OpenVR.Settings: {fileID: 11400000, guid: bb20c147be65c4c71a60aaaaeb3cc2f4,
       type: 2}


### PR DESCRIPTION
##  📍이슈 번호
#79 뒤로가기 구현 & UI 통일성 높이기

## ✍️ 주요 변경 사항
* 뒤로가기 스크립트가 추가되었습니다.
  * 해당 스크립트는 각 씬 플레이어에 그냥 달기만 하면 바로 사용 가능합니다. 시뮬레이터 기준 마우스 휠 버튼을 누르면 메인 씬으로 돌아갑니다.
* 메인 씬에서 자연재해 관련 씬으로 넘어가는 로직을 모두 연결했습니다.
* 지진 씬에서 피드백 / 종료 UI를 통일시켰습니다.

##  🙏 코드 리뷰 참고 사항
* 뒤로가기 UIUX에 관련해서 버튼을 한번 누르고 뒤로 가시겠습니까? 를 띄우고 한번 더 누르게 해서 뒤로 가고, 엔딩 시점에서는 한번만 누르면 뒤로 가게 만들기보다는 전체 상황에서 뒤로가기를 한번만 눌렀을 때 바로 메인 씬으로 보내고, 모든 씬의 엔딩 시점에서 그립 버튼을 눌러 메인으로 돌아가라고 안내하는 게 더 통일성 있어 보일 것 같았습니다. 테스트하면서 피드백 남겨주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Vive 컨트롤러 그립 버튼으로 언제든 메인 씬으로 즉시 복귀 가능.
  - 태풍 연습 모드 종료 시 전용 클리어 UI 패널 표시 및 안내 문구 제공, 메인으로 돌아가는 버튼 추가.
- Bug Fixes
  - 자연 모드(리얼)에서 한 장면만 반복되던 문제를 수정하여 다양한 장면이 무작위로 선택되도록 개선.
  - 산업 모드(리얼)에서 선택되는 장면 범위를 조정해 장면 분포를 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->